### PR TITLE
bug fixes and  neg instruction support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ include(CTest)
 
 set(PROJECT_AUTHOR 0xADE1A1DE)
 set(PROJECT_LICENSE "Apache License 2.0")
+set(CMAKE_VERBOSE_MAKEFILE ON)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 

--- a/src/assemblyline.c
+++ b/src/assemblyline.c
@@ -110,6 +110,7 @@ asm_create_instance(uint8_t* buffer, int len)
     al->debug     = false;
     al->finalized = false;
     asm_build_index_tables(al);
+    // asm_set_all(al, ASM_OPT_STRICT);
     return al;
 }
 

--- a/src/common.h
+++ b/src/common.h
@@ -43,12 +43,15 @@
 #define NEG32BIT 0xffffffff00000000
 #define NEG8BIT 0xffffffffffffff00
 #define NEG80BIT 0xffffffffffffff80
+#define NEG80_32BIT 0xffffff80
 #define MAX_SIGNED_8BIT 0x7f
 #define MAX_UNSIGNED_8BIT 0xff
 #define MAX_UNSIGNED_16BIT 0xffff
 #define MAX_SIGNED_32BIT 0x7fffffff
 #define MAX_UNSIGNED_32BIT 0xffffffff
 #define NEG32BIT_CHECK 0x80000000
+// check if a number is at least 32 bits
+#define X32BIT_CHECK 0x10000000
 #define NEG8BIT_CHECK 0x80
 
 // set register length to 1 byte
@@ -134,10 +137,10 @@
 
 // used only in tokenizer
 #define IN_RANGE(var, lower, upper) ((var >= lower) && (var <= upper))
-#define DO_NOT_PAD(reduce, set)                                                                                        \
-    reduce &= MAX_UNSIGNED_32BIT;                                                                                      \
-    set = true;
-
+#define DO_NOT_PAD(reduce, set, mask)                                          \
+  reduce &= mask;                                                              \
+  set = true;
+  
 // keyword length
 #define DWORD_LEN 5
 #define BYTE_LEN 4

--- a/src/enums.h
+++ b/src/enums.h
@@ -196,6 +196,7 @@ typedef enum
     movzx,
     mulpd,
     mulx,
+    neg,
     nop,
     not,
     or,

--- a/src/instructions.c
+++ b/src/instructions.c
@@ -166,6 +166,7 @@ const struct instr_table INSTR_TABLE[] = {
     {"movzx",       movzx,       {rr, rm},   RM,  OTHER,          NA,  NA,  4,  {REX, 0x0f, 0xb6, REG}},
     {"mulpd",       mulpd,       {NA, vv},   RM,  VECTOR,         NA,  NA,  5,  {0x66, REX, 0x0f, 0x59, REG}},
     {"mulx",        mulx,        {rrr, rrm}, RVM, VECTOR_EXT,     NA,  NA,  3,  {VEX(NDD,LZ,XF2,X0F38,W0_W1), 0xf6, REG}},
+    {"neg",         neg,         {r, m},     M,   OTHER,          1,   3,   3,  {REX, 0xf6, REG}},
     {"nop",         nop,         {n,  n},    NA,  OTHER,          NA,  NA,  1,  {0x90}},
     {"nop2",        nop,         {n,  n},    NA,  OTHER,          NA,  NA,  2,  {0x66, 0x90}},
     {"nop3",        nop,         {n,  n},    NA,  OTHER,          NA,  NA,  3,  {0x0f, 0x1f, 0x00}},

--- a/src/parser.c
+++ b/src/parser.c
@@ -70,8 +70,8 @@ line_to_instr(struct instr* instr_data, char* filtered_asm_str)
         opd_type[i] = instr_data->opd[i].type;
     operand_format opd_format = get_opd_format(opd_type);
     FAIL_IF_VAR(opd_format == opd_error, "illegal operand format: %s\n", opd_type)
-    // jcc [MEM] no register
-    if ( opd_format == m && instr_data->opd[0].str[0] == '\0' )
+    // jmp [MEM] no register
+    if (opd_format == m && instr_data->opd[0].str[0] == '\0' && instr_data->opd[0].sib[0] == '\0') 
     {
         instr_data->mod_disp &= MOD16;
         instr_data->keyword.is_short = true;
@@ -105,7 +105,7 @@ line_to_instr(struct instr* instr_data, char* filtered_asm_str)
     if ( INSTR_TABLE[instr_data->key].type == CONTROL_FLOW && IN_RANGE(instr_data->cons, NEG32BIT + 1, NEG64BIT) )
         instr_data->cons &= 0xffffffff;
     // encode for the reg_hex value and op_offset for instruction
-    if ( instr_data->opd[0].reg != reg_none )
+    if ( instr_data->opd[0].reg != reg_none || instr_data->opd[0].index != reg_none)
     {
         // gets all offsets
         encode_offset(instr_data);

--- a/src/prefix.c
+++ b/src/prefix.c
@@ -133,6 +133,8 @@ get_reg(struct instr* instrc, struct operand* m, int r)
             m->reg          = NO_BASE;
             instrc->no_base = true;
         }
+        if(m->reg == NO_BASE)
+            instrc->mod_disp = 0;
     }
     // check for index register
     if ( m->index == reg_none )

--- a/src/reg_parser.c
+++ b/src/reg_parser.c
@@ -62,11 +62,14 @@ process_neg_disp(uint32_t neg_num)
 }
 
 int
-get_opcode_offset(asm_reg reg_value)
+get_opcode_offset(struct instr *instrc)
 {
 
-    unsigned int index = reg_value & MODE_MASK;
-    if ( IN_RANGE(index, reg16, ext64) )
+    unsigned int base = instrc->opd[0].reg & MODE_MASK;
+    unsigned int index = instrc->opd[0].index & MODE_MASK;
+    if (IN_RANGE(base, reg16, ext64))
+        return 1;
+    else if (IN_RANGE(index, reg16, ext64))
         return 1;
     else
         return NONE;
@@ -99,6 +102,7 @@ get_reg_str(char* opd_str, char* reg)
             return;
     }
 }
+
 static unsigned int
 check_sib_disp(struct instr* instruc, char scale, char next)
 {
@@ -125,6 +129,7 @@ check_sib_disp(struct instr* instruc, char scale, char next)
     }
     return EXIT_SUCCESS;
 }
+
 unsigned int
 get_index_reg(struct instr* instruc, char* mem, char* reg)
 {

--- a/src/reg_parser.h
+++ b/src/reg_parser.h
@@ -29,7 +29,7 @@
  * returns an opcode offset based on the value of @param reg_value
  */
 int
-get_opcode_offset(asm_reg reg_value);
+get_opcode_offset(struct instr *instrc);
 
 /**
  * finds the register in @param str and copies the characters to @param reg


### PR DESCRIPTION
To keep this fork up-to-date:

- added support for neg: Two's Complement Negation

- fixed a bug where shift and rotate instruction produce the wrong opcode 
   when immediate is zero 

- fixed a bug when using sib addressing with no base and a single operand

- fixed a bug when using 32-bit immediate